### PR TITLE
Add very basic test that module can be used

### DIFF
--- a/t/00-use-module.t
+++ b/t/00-use-module.t
@@ -1,0 +1,9 @@
+use v6;
+
+use Test;
+
+plan 1;
+
+use-ok 'Perl6::Tracer';
+
+# vim: expandtab shiftwidth=4 ft=perl6


### PR DESCRIPTION
At the least a module should be able to be used without error.  This change
adds such a test, which in turn highlighted a deprecated code issue.
