### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Perl6/Tracer.pm
+++ b/lib/Perl6/Tracer.pm
@@ -1,5 +1,5 @@
 use Perl6::Parsing;
-class Perl6::Tracer;
+unit class Perl6::Tracer;
 constant $debug = 0;
 
 has @.tokens;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.
