### PR TITLE
fix shebang issue

### DIFF
--- a/lib/Rakudo/Perl6/Tracer.pm
+++ b/lib/Rakudo/Perl6/Tracer.pm
@@ -13,6 +13,24 @@ method new() {
   self.bless(  );
 }
 
+submethod get_first_token() {
+  my $line = "";
+  for @!tokens[0..*] -> @token {
+    my $token =  $text.substr(@token[1],@token[2]-@token[1]);
+    if ($token ~~ /(.*?)\n/)
+    {
+      $line~= $0;
+      last;
+    }
+    else
+    {
+      $line~= $token;
+    }
+    $line~~s:g/(<[{"$@%]>)/\\$0/;
+  }
+  return $line;
+}
+
 method insertline($p)
   {
     my $rest = "";
@@ -67,8 +85,18 @@ method trace(%options,$text)
   
   my $tracenext = False;
 
+  # do not note a shebang, it ruins scripts
+  my $firsttoken =  self.get_first_token();
+  if not ($firsttoken ~~ /^\#\!/)
+  {
+    self.insertline(0) 
+  }
+  else 
+  {
+    $lineno--;
+    $tracenext = True;
+  }
 
-  self.insertline(0);
   
   note "before for" if $debug;
   

--- a/t/01-shebang.t
+++ b/t/01-shebang.t
@@ -1,0 +1,14 @@
+use v6;
+
+use Test;
+use lib 'lib';
+use Rakudo::Perl6::Tracer;
+
+plan 1;
+my $tracer = Rakudo::Perl6::Tracer.new();
+my $code = "#! /usr/bin/env perl6 \n use v6; \n  use Rakudo::Perl6::Tracer; ";
+my $result = $tracer.trace({},$code); #  trace the content
+ok (not $result ~~ /^note/), "Did not note shebang";
+
+
+# vim: ft=perl6


### PR DESCRIPTION
Right now the tracer will note every first line no matter what. 
When tracing scripts that start with a s shebang this is a problem as it ruins the script.
The following commit is a quick work around for the issue, and includes a simple test.
