### PR TITLE
Don't trace multi routines

### DIFF
--- a/bin/trace.p6
+++ b/bin/trace.p6
@@ -1,4 +1,3 @@
-use lib 'lib';
 use Rakudo::Perl6::Tracer;
 
 sub getnextargument($index, $explanation)

--- a/bin/trace.p6
+++ b/bin/trace.p6
@@ -1,3 +1,4 @@
+use lib 'lib';
 use Rakudo::Perl6::Tracer;
 
 sub getnextargument($index, $explanation)

--- a/lib/Rakudo/Perl6/Tracer.pm
+++ b/lib/Rakudo/Perl6/Tracer.pm
@@ -26,7 +26,6 @@ submethod get_first_token() {
     {
       $line~= $token;
     }
-    $line~~s:g/(<[{"$@%]>)/\\$0/;
   }
   return $line;
 }
@@ -87,11 +86,7 @@ method trace(%options,$text)
 
   # do not note a shebang, it ruins scripts
   my $firsttoken =  self.get_first_token();
-  if not ($firsttoken ~~ /^\#\!/)
-  {
-    self.insertline(0) 
-  }
-  else 
+  if ($firsttoken ~~ /^\#\!/)
   {
     $lineno--;
     $tracenext = True;
@@ -126,7 +121,8 @@ method trace(%options,$text)
         $tracenext = True;
       }
       
-      if ((@token[0][0].EXISTS-KEY("routine_declarator")))
+      if ((@token[0][0].EXISTS-KEY("routine_declarator")) 
+        || (@token[0][0].EXISTS-KEY("multi_declarator")))
       { 
         $tracenext = False;
       }

--- a/lib/Rakudo/Perl6/Tracer.pm
+++ b/lib/Rakudo/Perl6/Tracer.pm
@@ -82,14 +82,13 @@ method trace(%options,$text)
   
   
   
-  my $tracenext = False;
+  my $tracenext = True;
 
   # do not note a shebang, it ruins scripts
   my $firsttoken =  self.get_first_token();
   if ($firsttoken ~~ /^\#\!/)
   {
     $lineno--;
-    $tracenext = True;
   }
 
   

--- a/t/02-routines.t
+++ b/t/02-routines.t
@@ -1,0 +1,27 @@
+use v6;
+
+use Test;
+use lib 'lib';
+use Rakudo::Perl6::Tracer;
+
+plan 3;
+my $tracer = Rakudo::Perl6::Tracer.new();
+
+# test that proto declarations are not noted
+my $code_proto = "proto method( \$ ) \{\} ";
+my $result = $tracer.trace({},$code_proto); 
+ok (not $result ~~ /^note/), "Did not note proto declaration";
+
+# test that multi subs are not noted
+my $code_multi = "multi sub method() \{ \}";
+$result = $tracer.trace({},$code_multi); 
+ok (not $result ~~ /^note/), "Did not note multi sub declaration";
+
+# test that calls are noted
+# there are still bugs here with one liners
+my $code_call = "sub method \{ 1 \} \nmethod(1);";
+$result = $tracer.trace({},$code_call); 
+ok ($result ~~ /\nnote/), "Noted call";
+
+# vim: ft=perl6
+


### PR DESCRIPTION
Proto declarations and multi subs declarations should not be traced. 
This patch does this by checking for multi_declarator as well as routine_declarator.
A test is included.

Note that the tracer still has problems with one liners that don't use ; such as:
sub method { 1 }
which traces to 
sub method { note "line  1";1 note "line  1";}
I haven't looked in to fixing it however
